### PR TITLE
Enable http-mock to be used with PlayFramework 2.5.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ pomExtra := (
 )
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-netty-server" % "2.4.2",
+  "com.typesafe.play" %% "play-netty-server" % "2.5.4",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "com.ning" % "async-http-client" % "1.9.29" % "test"
 )

--- a/src/main/scala/sc/ala/http/mock/ArrayByte.scala
+++ b/src/main/scala/sc/ala/http/mock/ArrayByte.scala
@@ -2,12 +2,14 @@ package sc.ala.http.mock
 
 import java.util
 
+import akka.util.ByteString
+
 /**
  * almost same as Array[Byte], but this allows easy equality
  */
-final case class ArrayByte(value: Array[Byte]) {
+final case class ArrayByte(value: ByteString) {
   def ===(that: ArrayByte): Boolean = {
-    util.Arrays.equals(this.value, that.value)
+    this.value == that.value
   }
 
   override def equals(that: Any): Boolean = that match {
@@ -15,19 +17,19 @@ final case class ArrayByte(value: Array[Byte]) {
     case array => false
   }
 
-  override def hashCode: Int = util.Arrays.hashCode(value)
+  override def hashCode: Int = value.hashCode()
 
   def length: Int = value.length
 
-  def copy(): ArrayByte = ArrayByte(value.clone())
+  def copy(): ArrayByte = ArrayByte(value)
 
   override def toString: String = {
     s"ArrayByte(length = ${value.length}, value = 0x${ArrayByte.byte2string(value, 32)})"
   }
 }
 
-object ArrayByte extends (Array[Byte] => ArrayByte) {
-  def byte2string(bytes: Array[Byte], maxSize: Int): String = {
+object ArrayByte extends (ByteString => ArrayByte) {
+  def byte2string(bytes: ByteString, maxSize: Int): String = {
     val builder = new java.lang.StringBuilder
     var i = 0
     val len = bytes.length min maxSize

--- a/src/main/scala/sc/ala/http/mock/EachLogExpectationBuilder.scala
+++ b/src/main/scala/sc/ala/http/mock/EachLogExpectationBuilder.scala
@@ -2,7 +2,10 @@ package sc.ala.http.mock
 
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets.UTF_8
+
+import akka.util.ByteString
 import play.api.mvc.Headers
+
 import scala.concurrent.duration._
 
 final case class EachLogExpectationBuilder(
@@ -14,7 +17,7 @@ final case class EachLogExpectationBuilder(
 ) {
   def method: String = methodOpt.fold("")(_.value)
 
-  def body(v: String, charset: Charset = UTF_8): EachLogExpectationBuilder = copy(bodyOpt = Some(ArrayByte(v.getBytes(charset))))
+  def body(v: String, charset: Charset = UTF_8): EachLogExpectationBuilder = copy(bodyOpt = Some(ArrayByte(ByteString(v.getBytes(charset)))))
 
   def count(v: Int): EachLogExpectationBuilder = copy(count = v)
 
@@ -32,7 +35,7 @@ final case class EachLogExpectationBuilder(
       throw new IllegalArgumentException("bodies and count > 1 are exclusive")
     }
 
-    AllLogExpectationBuilder(methodOpt, headers, bodies.map(x => ArrayByte(x.getBytes(charset))), queue)
+    AllLogExpectationBuilder(methodOpt, headers, bodies.map(x => ArrayByte(ByteString(x.getBytes(charset)))), queue)
   }
 
   /** await result */


### PR DESCRIPTION
It'd be nice to use http-mock for the latest stable version of PlayFramework.

To do this, we need to fix asBytes(...)[1] conversion in this line[2] as the singnature(return type) of asBytes(...) has changed from Array[Byte] to ByteString in 2.5.4.

[1] https://github.com/playframework/playframework/blob/2.5.4/framework/src/play/src/main/scala/play/api/mvc/ContentTypes.scala#L235-L245
[2] https://github.com/maiha/http-mock/blob/0.3.1/src/main/scala/sc/ala/http/mock/Setting.scala#L24
