### PR TITLE
Upgrade Scala version to 2.11.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import sbt.Keys._
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 scalacOptions := Seq(
   "-encoding", "UTF-8", "-target:jvm-1.8", "-deprecation",


### PR DESCRIPTION
As the latest scala stable version is 2.11.8, it'd be good for us to use the version. :)
